### PR TITLE
Feature/fwr 814 integrate eg21g

### DIFF
--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -33,6 +33,7 @@
 #include "cellular_common.h"
 #include "cellular_common_portable.h"
 #include "cellular_bg96.h"
+#include "cellular_api.h"
 
 /*-----------------------------------------------------------*/
 
@@ -215,6 +216,7 @@ CellularError_t Cellular_ModuleCleanUp( const CellularContext_t * pContext )
 CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularModemInfo_t pModemInfo = {0};
     CellularAtReq_t atReqGetNoResult =
     {
         NULL,
@@ -269,7 +271,28 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
         }
 
-        if( cellularStatus == CELLULAR_SUCCESS )
+        if ( cellularStatus == CELLULAR_SUCCESS )
+        {
+            if (cellularStatus == CELLULAR_SUCCESS)
+            {
+                cellularStatus = Cellular_GetModemInfo(pContext, &pModemInfo);
+        
+                if (strcmp(pModemInfo.modelId, "BG96"))
+                {
+                    cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_BG96;
+                }
+                else if (strcmp(pModemInfo.modelId, "EG21G"))
+                {
+                    cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_EG21G;
+                }
+                else
+                {
+                    cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_UNKNOWN;
+                }
+            }
+        }
+
+        if( ( cellularStatus == CELLULAR_SUCCESS ) && ( cellularBg96Context.moduleType == CELLULAR_MODULE_TYPE_BG96 ) )
         {
             /* Configure Band configuration to all bands. */
             atReqGetNoResult.pAtCmd = "AT+QCFG=\"band\",f,400a0e189f,a0e189f";
@@ -278,12 +301,12 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 
         if( cellularStatus == CELLULAR_SUCCESS )
         {
-            /* Configure RAT(s) to be Searched to Automatic. */
-            atReqGetNoResult.pAtCmd = "AT+QCFG=\"nwscanmode\",0,1";
+            /* Configure RAT(s) to be Searched to LTE only. */
+            atReqGetNoResult.pAtCmd = "AT+QCFG=\"nwscanmode\",3,1";
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
         }
 
-        if( cellularStatus == CELLULAR_SUCCESS )
+        if( ( cellularStatus == CELLULAR_SUCCESS ) && ( cellularBg96Context.moduleType == CELLULAR_MODULE_TYPE_BG96 ))
         {
             /* Configure Network Category to be Searched under LTE RAT to LTE Cat M1 and Cat NB1. */
             atReqGetNoResult.pAtCmd = "AT+QCFG=\"iotopmode\",2,1";
@@ -297,7 +320,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
         }
 
-        if( cellularStatus == CELLULAR_SUCCESS )
+        if( ( cellularStatus == CELLULAR_SUCCESS ) && ( cellularBg96Context.moduleType == CELLULAR_MODULE_TYPE_BG96 ) )
         {
             retAppendRat = appendRatList( ratSelectCmd, CELLULAR_CONFIG_DEFAULT_RAT );
             configASSERT( retAppendRat == true );

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -277,11 +277,11 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             {
                 cellularStatus = Cellular_GetModemInfo(pContext, &pModemInfo);
         
-                if (strcmp(pModemInfo.modelId, "BG96"))
+                if (strcmp(pModemInfo.modelId, "BG96") == 0)
                 {
                     cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_BG96;
                 }
-                else if (strcmp(pModemInfo.modelId, "EG21G"))
+                else if (strcmp(pModemInfo.modelId, "EG21G") == 0)
                 {
                     cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_EG21G;
                 }

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -311,7 +311,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 
         if( ( cellularStatus == CELLULAR_SUCCESS ) && ( cellularBg96Context.moduleType == CELLULAR_MODULE_TYPE_BG96 ))
         {
-            /* Configure Network Category to be Searched under LTE RAT to LTE Cat M1 and Cat NB1. */
+            /* Configure Network Category to be Searched under LTE RAT to LTE Cat M1 only. */
             atReqGetNoResult.pAtCmd = "AT+QCFG=\"iotopmode\",0,1";
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
         }

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -273,15 +273,14 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 
         if ( cellularStatus == CELLULAR_SUCCESS )
         {
-            if (cellularStatus == CELLULAR_SUCCESS)
+            cellularStatus = Cellular_GetModemInfo(pContext, &pModemInfo);
+            if ( cellularStatus == CELLULAR_SUCCESS )
             {
-                cellularStatus = Cellular_GetModemInfo(pContext, &pModemInfo);
-        
                 if (strcmp(pModemInfo.modelId, "BG96") == 0)
                 {
                     cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_BG96;
                 }
-                else if (strcmp(pModemInfo.modelId, "EG21G") == 0)
+                else if (strcmp(pModemInfo.modelId, "EG21") == 0)
                 {
                     cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_EG21G;
                 }
@@ -289,6 +288,10 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
                 {
                     cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_UNKNOWN;
                 }
+            }
+            else
+            {
+                cellularBg96Context.moduleType = CELLULAR_MODULE_TYPE_UNKNOWN;
             }
         }
 
@@ -309,13 +312,13 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
         if( ( cellularStatus == CELLULAR_SUCCESS ) && ( cellularBg96Context.moduleType == CELLULAR_MODULE_TYPE_BG96 ))
         {
             /* Configure Network Category to be Searched under LTE RAT to LTE Cat M1 and Cat NB1. */
-            atReqGetNoResult.pAtCmd = "AT+QCFG=\"iotopmode\",2,1";
+            atReqGetNoResult.pAtCmd = "AT+QCFG=\"iotopmode\",0,1";
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
         }
 
         if( cellularStatus == CELLULAR_SUCCESS )
         {
-            /* Configure Network Category to be Searched under LTE RAT to LTE Cat M1 and Cat NB1. */
+            /* Enable data roaming */
             atReqGetNoResult.pAtCmd = "AT+QCFG=\"roamservice\",2,1";
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
         }

--- a/source/cellular_bg96.h
+++ b/source/cellular_bg96.h
@@ -49,6 +49,14 @@
 #define DATA_SEND_TIMEOUT_MS                       ( 50000UL )
 #define DATA_READ_TIMEOUT_MS                       ( 50000UL )
 
+// @brief Enum representing type of module currently in use
+typedef enum CellularModuleType
+{
+    CELLULAR_MODULE_TYPE_UNKNOWN = 0,
+    CELLULAR_MODULE_TYPE_BG96, 
+    CELLULAR_MODULE_TYPE_EG21G,
+} CellularModuleType_t;
+
 /**
  * @brief DNS query result.
  */
@@ -78,6 +86,7 @@ typedef struct cellularModuleContext
     uint8_t dnsIndex;              /* DNS query current index. */
     char * pDnsUsrData;            /* DNS user data to store the result. */
     CellularDnsResultEventCallback_t dnsEventCallback;
+    CellularModuleType_t moduleType; /* Represents the current cellular module being used */
 } cellularModuleContext_t;
 
 CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,

--- a/source/cellular_bg96.h
+++ b/source/cellular_bg96.h
@@ -49,13 +49,7 @@
 #define DATA_SEND_TIMEOUT_MS                       ( 50000UL )
 #define DATA_READ_TIMEOUT_MS                       ( 50000UL )
 
-// @brief Enum representing type of module currently in use
-typedef enum CellularModuleType
-{
-    CELLULAR_MODULE_TYPE_UNKNOWN = 0,
-    CELLULAR_MODULE_TYPE_BG96, 
-    CELLULAR_MODULE_TYPE_EG21G,
-} CellularModuleType_t;
+#include "cellular_bg96_types.h"
 
 /**
  * @brief DNS query result.

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -4708,32 +4708,22 @@ CellularError_t Cellular_MqttReadIncomingPublish( CellularHandle_t cellularHandl
     return cellularStatus;
 }
 
-CellularError_t Cellular_DetectModuleType(CellularHandle_t cellularHandle)
+CellularError_t Cellular_GetModuleType(CellularHandle_t cellularHandle, CellularModuleType_t * moduleType)
 {
     CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
-    CellularError_t cellularStatus = CELLULAR_SUCCESS;
-    CellularModemInfo_t pModemInfo = {0};
     cellularModuleContext_t * pModuleContext = NULL;
-
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
 
     cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
-
-    if (cellularStatus == CELLULAR_SUCCESS)
+    
+    if (pModuleContext != NULL)
     {
-        cellularStatus = Cellular_GetModemInfo(cellularHandle, &pModemInfo);
-
-        if (strcmp(pModemInfo.modelId, "BG96"))
-        {
-            pModuleContext->moduleType = CELLULAR_MODULE_TYPE_BG96;
-        }
-        else if (strcmp(pModemInfo.modelId, "EG21G"))
-        {
-            pModuleContext->moduleType = CELLULAR_MODULE_TYPE_EG21G;
-        }
-        else
-        {
-            pModuleContext->moduleType = CELLULAR_MODULE_TYPE_UNKNOWN;
-        }
+        *moduleType = pModuleContext->moduleType;
+    }
+    else
+    {
+        *moduleType = CELLULAR_MODULE_TYPE_UNKNOWN;
+        cellularStatus = CELLULAR_UNKNOWN;
     }
 
     return cellularStatus;

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -4728,3 +4728,45 @@ CellularError_t Cellular_GetModuleType(CellularHandle_t cellularHandle, Cellular
 
     return cellularStatus;
 }
+
+CellularError_t Cellular_GetIPAddress( CellularHandle_t cellularHandle,
+    uint8_t contextId,
+    char * pBuffer,
+    uint32_t bufferLength )
+{
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularModuleType_t moduleType;
+
+    // Skip error if it fails to get module type
+    Cellular_GetModuleType( cellularHandle, &moduleType );
+
+    cellularStatus = Cellular_CommonGetIPAddress( cellularHandle, contextId, pBuffer, bufferLength );
+
+    if ( ( cellularStatus == CELLULAR_SUCCESS ) && ( moduleType != CELLULAR_MODULE_TYPE_BG96 ) )
+    {
+        // Remove quotes from the IP string in-place
+        size_t readIndex  = 0;
+        size_t writeIndex = 0;
+
+        while (pBuffer[readIndex] != '\0' && readIndex < bufferLength)
+        {
+            if (pBuffer[readIndex] != '\"')  // Skip quote characters
+            {
+                pBuffer[writeIndex++] = pBuffer[readIndex];
+            }
+            readIndex++;
+        }
+
+        // Null-terminate the modified string
+        if (writeIndex < bufferLength)
+        {
+            pBuffer[writeIndex] = '\0';
+        }
+        else if (bufferLength > 0)
+        {
+            pBuffer[bufferLength - 1] = '\0';
+        }
+    }
+    
+    return cellularStatus;
+}

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -4735,36 +4735,39 @@ CellularError_t Cellular_GetIPAddress( CellularHandle_t cellularHandle,
     uint32_t bufferLength )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
-    CellularModuleType_t moduleType;
-
-    // Skip error if it fails to get module type
-    Cellular_GetModuleType( cellularHandle, &moduleType );
 
     cellularStatus = Cellular_CommonGetIPAddress( cellularHandle, contextId, pBuffer, bufferLength );
 
-    if ( ( cellularStatus == CELLULAR_SUCCESS ) && ( moduleType != CELLULAR_MODULE_TYPE_BG96 ) )
+    if ( cellularStatus == CELLULAR_SUCCESS )
     {
-        // Remove quotes from the IP string in-place
-        size_t readIndex  = 0;
-        size_t writeIndex = 0;
+        CellularModuleType_t moduleType;
+        
+        Cellular_GetModuleType( cellularHandle, &moduleType );
 
-        while (pBuffer[readIndex] != '\0' && readIndex < bufferLength)
+        if (moduleType != CELLULAR_MODULE_TYPE_BG96)
         {
-            if (pBuffer[readIndex] != '\"')  // Skip quote characters
+            // Remove quotes from the IP string in-place
+            size_t readIndex  = 0;
+            size_t writeIndex = 0;
+
+            while (pBuffer[readIndex] != '\0' && readIndex < bufferLength)
             {
-                pBuffer[writeIndex++] = pBuffer[readIndex];
+                if (pBuffer[readIndex] != '\"')  // Skip quote characters
+                {
+                    pBuffer[writeIndex++] = pBuffer[readIndex];
+                }
+                readIndex++;
             }
-            readIndex++;
-        }
 
-        // Null-terminate the modified string
-        if (writeIndex < bufferLength)
-        {
-            pBuffer[writeIndex] = '\0';
-        }
-        else if (bufferLength > 0)
-        {
-            pBuffer[bufferLength - 1] = '\0';
+            // Null-terminate the modified string
+            if (writeIndex < bufferLength)
+            {
+                pBuffer[writeIndex] = '\0';
+            }
+            else if (bufferLength > 0)
+            {
+                pBuffer[bufferLength - 1] = '\0';
+            }
         }
     }
     

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -276,7 +276,8 @@ static bool _parseSignalQuality( char * pQcsqPayload,
     {
         if( ( strcmp( pToken, "GSM" ) != 0 ) &&
             ( strcmp( pToken, "CAT-M1" ) != 0 ) &&
-            ( strcmp( pToken, "CAT-NB1" ) != 0 ) )
+            ( strcmp( pToken, "CAT-NB1" ) != 0 ) &&
+            ( strcmp( pToken, "LTE" ) != 0 ) )
         {
             parseStatus = false;
         }
@@ -3211,12 +3212,13 @@ CellularError_t Cellular_GetSimCardInfo( CellularHandle_t cellularHandle,
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
         {
-            pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetHplmn );
+            pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetIccid );
         }
 
         if( pktStatus == CELLULAR_PKT_STATUS_OK )
-        {
-            pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetIccid );
+        {   
+            // Not returning Hplmn status as it fails on some types of simcards e.g. telnyx
+            _Cellular_AtcmdRequestWithCallback( pContext, atReqGetHplmn );
         }
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
@@ -4031,6 +4033,41 @@ CellularError_t Cellular_MqttConfigureReceiveMode(CellularHandle_t cellularHandl
     return cellularStatus;
 }
 
+CellularError_t Cellular_MqttConfigureSendMode(CellularHandle_t cellularHandle,
+    uint8_t mqttContextId,
+    bool message_not_in_urc)
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    char atCommandBuffer[2*CELLULAR_AT_CMD_TYPICAL_MAX_SIZE] = {0};
+
+    CellularAtReq_t atReqConfigureSslContext =
+    {
+        atCommandBuffer,
+        CELLULAR_AT_NO_RESULT,
+        NULL,
+        NULL,
+        NULL,
+        0,
+    };
+
+    cellularStatus = _Cellular_CheckLibraryStatus( pContext );
+
+    if( cellularStatus == CELLULAR_SUCCESS )
+    {
+        /* The return value of snprintf is not used.
+        * The max length of the string is fixed and checked offline. */
+        /* coverity[misra_c_2012_rule_21_6_violation]. */
+        ( void ) snprintf(atCommandBuffer, 2*CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "AT+QMTCFG=\"send/mode\",%d,%d",
+                mqttContextId, (uint8_t)message_not_in_urc);
+        pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqConfigureSslContext );
+        cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+    }
+
+    return cellularStatus;
+}
+
 CellularError_t Cellular_MqttOpen(CellularHandle_t cellularHandle,
         uint8_t mqttContextId,
         const char * endpoint,
@@ -4209,6 +4246,7 @@ CellularError_t Cellular_MqttPublish(CellularHandle_t cellularHandle,
                                      uint32_t * sentDataLength )
 {
     CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    cellularModuleContext_t * pModuleContext = NULL;
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     uint32_t sendTimeout = DATA_SEND_TIMEOUT_MS;
@@ -4248,8 +4286,16 @@ CellularError_t Cellular_MqttPublish(CellularHandle_t cellularHandle,
         /* Send data length check. */
         if( messageLength <= ( uint32_t ) CELLULAR_MQTT_MAX_SEND_DATA_LEN )
         {
+
+            cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
+            char * publishCommand = "AT+QMTPUBEX=";
+            if ( pModuleContext != NULL && pModuleContext->moduleType == CELLULAR_MODULE_TYPE_BG96 )
+            {
+                publishCommand = "AT+QMTPUB=";
+            }
+
             ( void ) snprintf( cmdBuf, 6*CELLULAR_AT_CMD_TYPICAL_MAX_SIZE, "%s%d,%d,%d,%d,\"%s\",%ld",
-                               "AT+QMTPUB=", mqttContextId, messageId, (uint8_t)qos, retain, topic, atDataReqMqttPublish.dataLen);
+                               publishCommand, mqttContextId, messageId, (uint8_t)qos, retain, topic, atDataReqMqttPublish.dataLen);
             pktStatus = _Cellular_AtcmdDataSend( pContext, atReqSocketSend, atDataReqMqttPublish,
                                                  socketSendDataPrefix, NULL,
                                                  PACKET_REQ_TIMEOUT_MS, sendTimeout, 0U );
@@ -4656,6 +4702,37 @@ CellularError_t Cellular_MqttReadIncomingPublish( CellularHandle_t cellularHandl
             /* Reset data handling parameters. */
             LogError( ( "_Cellular_MqttReadIncomingPublish: Data Receive fail, pktStatus: %d", pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+        }
+    }
+
+    return cellularStatus;
+}
+
+CellularError_t Cellular_DetectModuleType(CellularHandle_t cellularHandle)
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularModemInfo_t pModemInfo = {0};
+    cellularModuleContext_t * pModuleContext = NULL;
+
+
+    cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
+
+    if (cellularStatus == CELLULAR_SUCCESS)
+    {
+        cellularStatus = Cellular_GetModemInfo(cellularHandle, &pModemInfo);
+
+        if (strcmp(pModemInfo.modelId, "BG96"))
+        {
+            pModuleContext->moduleType = CELLULAR_MODULE_TYPE_BG96;
+        }
+        else if (strcmp(pModemInfo.modelId, "EG21G"))
+        {
+            pModuleContext->moduleType = CELLULAR_MODULE_TYPE_EG21G;
+        }
+        else
+        {
+            pModuleContext->moduleType = CELLULAR_MODULE_TYPE_UNKNOWN;
         }
     }
 

--- a/source/cellular_bg96_api.h
+++ b/source/cellular_bg96_api.h
@@ -8,6 +8,8 @@
 /* IoT Cellular data types. */
 #include "cellular_types.h"
 
+#include "cellular_bg96_types.h"
+
 #define BG96_API_NO_SSL_CONTEXT_ID    (-1)
 #define BG96_API_MQTT_SSL_CONTEXT_ID  (1)
 #define BG96_API_HTTPS_SSL_CONTEXT_ID (2)
@@ -195,6 +197,9 @@ CellularError_t Cellular_MqttReadIncomingPublish( CellularHandle_t cellularHandl
                                                   char * topic,
                                                   uint32_t topicBufferLength,
                                                   uint32_t * receivedTopicLength);
+
+CellularError_t Cellular_GetModuleType(CellularHandle_t cellularHandle, 
+                                       CellularModuleType_t * moduleType);
 
 
 #endif

--- a/source/cellular_bg96_api.h
+++ b/source/cellular_bg96_api.h
@@ -146,6 +146,10 @@ CellularError_t Cellular_MqttConfigureReceiveMode(CellularHandle_t cellularHandl
                                                   bool message_not_in_urc,
                                                   bool message_length_in_urc);
 
+CellularError_t Cellular_MqttConfigureSendMode(CellularHandle_t cellularHandle,
+                                                uint8_t mqttContextId,
+                                                bool message_not_in_urc);
+
 CellularError_t Cellular_MqttOpen(CellularHandle_t cellularHandle,
                                   uint8_t mqttContextId,
                                   const char* endpoint,

--- a/source/cellular_bg96_types.h
+++ b/source/cellular_bg96_types.h
@@ -1,0 +1,12 @@
+#ifndef __CELLULAR_BG96_TYPES_H__
+#define __CELLULAR_BG96_TYPES_H__
+
+// @brief Enum representing type of module currently in use
+typedef enum CellularModuleType
+{
+    CELLULAR_MODULE_TYPE_UNKNOWN = 0,
+    CELLULAR_MODULE_TYPE_BG96, 
+    CELLULAR_MODULE_TYPE_EG21G,
+} CellularModuleType_t;
+
+#endif

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -95,6 +95,7 @@ CellularAtParseTokenMap_t CellularUrcHandlerTable[] =
     { "QMTDISC",           _Cellular_ProcessMqttDisconnect  },
     { "QMTOPEN",           _Cellular_ProcessMqttOpen        },
     { "QMTPUB",            _Cellular_ProcessMqttPublish     },
+    { "QMTPUBEX",          _Cellular_ProcessMqttPublish     },
     { "QMTRECV",           _Cellular_ProcessMqttReceive     },
     { "QMTSTAT",           _Cellular_ProcessMqttState       },
     { "QMTSUB",            _Cellular_ProcessMqttSubscribe   },

--- a/source/cellular_bg96_wrapper.c
+++ b/source/cellular_bg96_wrapper.c
@@ -168,18 +168,6 @@ CellularError_t Cellular_RfOff( CellularHandle_t cellularHandle )
 
 /* FreeRTOS Cellular Library API. */
 /* coverity[misra_c_2012_rule_8_7_violation] */
-CellularError_t Cellular_GetIPAddress( CellularHandle_t cellularHandle,
-                                       uint8_t contextId,
-                                       char * pBuffer,
-                                       uint32_t bufferLength )
-{
-    return Cellular_CommonGetIPAddress( cellularHandle, contextId, pBuffer, bufferLength );
-}
-
-/*-----------------------------------------------------------*/
-
-/* FreeRTOS Cellular Library API. */
-/* coverity[misra_c_2012_rule_8_7_violation] */
 CellularError_t Cellular_GetModemInfo( CellularHandle_t cellularHandle,
                                        CellularModemInfo_t * pModemInfo )
 {


### PR DESCRIPTION
- Added module type to the module context. This gets set during initialisation. Currently two types supported, `EG21` and `BG96`.
- Added a few conditional checks throughout the code to allow for cross compatability between BG96 and EG21G.
- Modified network searches to only look at LTE and LTE CAT M1 rather than including NB-IOT. This will speed up network search times, particularly on Telnyx sims. 