### PR TITLE
feat: Implement Cellular_Ping for AT+QPING

### DIFF
--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -163,7 +163,19 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
             }
             else
             {
-                *ppModuleContext = ( void * ) &cellularBg96Context;
+                /* Create the queue for ping. */
+                cellularBg96Context.pktPingQueue = xQueueCreate( 1, sizeof( int32_t ) );
+
+                if( cellularBg96Context.pktPingQueue == NULL )
+                {
+                    vQueueDelete( cellularBg96Context.pktDnsQueue );
+                    PlatformMutex_Destroy( &cellularBg96Context.contextMutex );
+                    cellularStatus = CELLULAR_NO_MEMORY;
+                }
+                else
+                {
+                    *ppModuleContext = ( void * ) &cellularBg96Context;
+                }
             }
         }
 
@@ -195,6 +207,9 @@ CellularError_t Cellular_ModuleCleanUp( const CellularContext_t * pContext )
     {
         /* Delete DNS queue. */
         vQueueDelete( cellularBg96Context.pktDnsQueue );
+
+        /* Delete ping queue. */
+        vQueueDelete( cellularBg96Context.pktPingQueue );
 
         /* Delete the mutex for DNS. */
         PlatformMutex_Destroy( &cellularBg96Context.contextMutex );

--- a/source/cellular_bg96.h
+++ b/source/cellular_bg96.h
@@ -82,6 +82,9 @@ typedef void ( * CellularDnsResultEventCallback_t )( cellularModuleContext_t * p
                                                      char * pDnsResult,
                                                      char * pDnsUsrData );
 
+typedef void ( * CellularPingResultEventCallback_t )( cellularModuleContext_t * pModuleContext,
+                                                      int32_t pingResult );
+
 typedef struct cellularModuleContext
 {
     PlatformMutex_t contextMutex; /* Mutex for module context. */
@@ -91,6 +94,10 @@ typedef struct cellularModuleContext
     uint8_t dnsResultNumber;   /* DNS query result number. */
     uint8_t dnsIndex;          /* DNS query current index. */
     char * pDnsUsrData;        /* DNS user data to store the result. */
+
+    /* Ping related variables. */
+    QueueHandle_t pktPingQueue;                      /* Queue to receive the +QPING URC result code. */
+    CellularPingResultEventCallback_t pingEventCallback; /* Set while a Cellular_Ping call is in progress. */
 
     #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
         uint8_t pSocketBuffer[ CELLULAR_NUM_SOCKET_MAX ][ CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE ];

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -2200,6 +2200,124 @@ static void _dnsResultCallback( cellularModuleContext_t * pModuleContext,
 
 /*-----------------------------------------------------------*/
 
+static CellularError_t registerPingEventCallback( cellularModuleContext_t * pModuleContext,
+                                                  CellularPingResultEventCallback_t pingEventCallback )
+{
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+
+    if( pModuleContext == NULL )
+    {
+        cellularStatus = CELLULAR_INVALID_HANDLE;
+    }
+    else
+    {
+        pModuleContext->pingEventCallback = pingEventCallback;
+    }
+
+    return cellularStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+static void _pingResultCallback( cellularModuleContext_t * pModuleContext,
+                                 int32_t pingResult )
+{
+    if( pModuleContext == NULL )
+    {
+        return;
+    }
+
+    ( void ) registerPingEventCallback( pModuleContext, NULL );
+
+    if( xQueueSend( pModuleContext->pktPingQueue, &pingResult, ( TickType_t ) 0 ) != pdPASS )
+    {
+        LogDebug( ( "_pingResultCallback sends pktPingQueue fail" ) );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+int32_t Cellular_Ping( CellularHandle_t cellularHandle,
+                       uint8_t contextId,
+                       const char * pHost,
+                       uint32_t timeoutS )
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    char cmdBuf[ CELLULAR_AT_CMD_MAX_SIZE ] = { '\0' };
+    int32_t pingResult = -1;
+    cellularModuleContext_t * pModuleContext = NULL;
+    CellularAtReq_t atReqPing =
+    {
+        cmdBuf,
+        CELLULAR_AT_NO_RESULT,
+        NULL,
+        NULL,
+        NULL,
+        0,
+    };
+
+    cellularStatus = _Cellular_CheckLibraryStatus( pContext );
+
+    if( cellularStatus != CELLULAR_SUCCESS )
+    {
+        LogDebug( ( "_Cellular_CheckLibraryStatus failed" ) );
+    }
+    else if( pHost == NULL )
+    {
+        cellularStatus = CELLULAR_BAD_PARAMETER;
+    }
+    else
+    {
+        cellularStatus = _Cellular_IsValidPdn( contextId );
+    }
+
+    if( cellularStatus == CELLULAR_SUCCESS )
+    {
+        cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
+    }
+
+    if( cellularStatus == CELLULAR_SUCCESS )
+    {
+        PlatformMutex_Lock( &pModuleContext->contextMutex );
+        ( void ) xQueueReset( pModuleContext->pktPingQueue );
+        cellularStatus = registerPingEventCallback( pModuleContext, _pingResultCallback );
+    }
+
+    if( cellularStatus == CELLULAR_SUCCESS )
+    {
+        ( void ) snprintf( cmdBuf, sizeof( cmdBuf ), "AT+QPING=%u,\"%s\",%u,1", contextId, pHost, ( unsigned int ) timeoutS );
+        pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqPing );
+
+        if( pktStatus != CELLULAR_PKT_STATUS_OK )
+        {
+            LogError( ( "Cellular_Ping: AT command failed status=%d", pktStatus ) );
+            ( void ) registerPingEventCallback( pModuleContext, NULL );
+            PlatformMutex_Unlock( &pModuleContext->contextMutex );
+            return -1;
+        }
+    }
+
+    if( cellularStatus == CELLULAR_SUCCESS )
+    {
+        /* Wait for URC: modem timeout plus 2 s overhead. */
+        if( xQueueReceive( pModuleContext->pktPingQueue, &pingResult,
+                           pdMS_TO_TICKS( ( timeoutS + 2U ) * 1000U ) ) != pdTRUE )
+        {
+            LogDebug( ( "Cellular_Ping: URC timed out" ) );
+            ( void ) registerPingEventCallback( pModuleContext, NULL );
+            pingResult = -1;
+        }
+
+        PlatformMutex_Unlock( &pModuleContext->contextMutex );
+    }
+
+    return pingResult;
+}
+
+/*-----------------------------------------------------------*/
+
 CellularError_t Cellular_SetRatPriority( CellularHandle_t cellularHandle,
                                          const CellularRat_t * pRatPriorities,
                                          uint8_t ratPrioritiesLength )

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -98,6 +98,8 @@ static void _Cellular_ProcessMqttState( CellularContext_t * pContext,
                                          char * pInputLine );
 static void _Cellular_ProcessMqttReceive( CellularContext_t * pContext,
                                          char * pInputLine );
+static void _Cellular_ProcessPingUrc( CellularContext_t * pContext,
+                                      char * pInputLine );
 
 /*-----------------------------------------------------------*/
 
@@ -122,6 +124,7 @@ CellularAtParseTokenMap_t CellularUrcHandlerTable[] =
     { "QMTSTAT",           _Cellular_ProcessMqttState       },
     { "QMTSUB",            _Cellular_ProcessMqttSubscribe   },
     { "QMTUNS",            _Cellular_ProcessMqttUnsubscribe },
+    { "QPING",             _Cellular_ProcessPingUrc         },
     { "QSIMSTAT",          _Cellular_ProcessSimstat         },
     { "QSSLOPEN",          _Cellular_ProcessSocketOpen      },
     { "QSSLURC",           _Cellular_ProcessSocketurc       },
@@ -1853,4 +1856,70 @@ static void _Cellular_ProcessMqttReceive( CellularContext_t * pContext,
     }
 
     LogDebug(("Receive URC completed with status %d", atCoreStatus));
+}
+
+/*-----------------------------------------------------------*/
+
+/* Handle +QPING: URC.
+ *
+ * Failure: +QPING: <errcode>          (non-zero errcode, e.g. 565, 569)
+ * Echo reply: +QPING: 0,"<ip>",<bytes>,<rtt>,<ttl>
+ * Summary: +QPING: 0,<sent>,<recv>,<min>,<max>,<avg>
+ *
+ * We fire the callback on the first URC (failure or echo reply) and ignore the
+ * summary, so the caller unblocks as soon as the first ping result is known.
+ */
+static void _Cellular_ProcessPingUrc( CellularContext_t * pContext,
+                                      char * pInputLine )
+{
+    cellularModuleContext_t * pModuleContext = NULL;
+    CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+    char * pToken = NULL;
+    char * pLocalInputLine = pInputLine;
+    int32_t resultCode = 0;
+
+    if( _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext ) != CELLULAR_SUCCESS )
+    {
+        return;
+    }
+
+    if( pModuleContext->pingEventCallback == NULL )
+    {
+        /* No active Cellular_Ping call — ignore (e.g. summary URC after callback cleared). */
+        return;
+    }
+
+    /* First token is the result code. */
+    atCoreStatus = Cellular_ATGetNextTok( &pLocalInputLine, &pToken );
+
+    if( atCoreStatus != CELLULAR_AT_SUCCESS )
+    {
+        return;
+    }
+
+    atCoreStatus = Cellular_ATStrtoi( pToken, 10, &resultCode );
+
+    if( atCoreStatus != CELLULAR_AT_SUCCESS )
+    {
+        return;
+    }
+
+    if( resultCode != 0 )
+    {
+        /* Failure URC: +QPING: <errcode> */
+        pModuleContext->pingEventCallback( pModuleContext, resultCode );
+    }
+    else
+    {
+        /* Zero result — check whether this is an echo reply or the summary line.
+         * Echo reply has a quoted IP as the next token; summary has a plain integer. */
+        atCoreStatus = Cellular_ATGetNextTok( &pLocalInputLine, &pToken );
+
+        if( ( atCoreStatus == CELLULAR_AT_SUCCESS ) && ( pToken != NULL ) && ( pToken[ 0 ] == '"' ) )
+        {
+            /* Echo reply: +QPING: 0,"<ip>",<bytes>,<rtt>,<ttl> */
+            pModuleContext->pingEventCallback( pModuleContext, 0 );
+        }
+        /* Summary line: +QPING: 0,<sent>,<recv>,...  — ignore, callback already cleared. */
+    }
 }

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -1889,6 +1889,15 @@ static void _Cellular_ProcessPingUrc( CellularContext_t * pContext,
         return;
     }
 
+    /* Strip any leading whitespace so the second-token quote check below is robust
+     * to firmware variants that pad commas with spaces. */
+    atCoreStatus = Cellular_ATRemoveLeadingWhiteSpaces( &pLocalInputLine );
+
+    if( atCoreStatus != CELLULAR_AT_SUCCESS )
+    {
+        return;
+    }
+
     /* First token is the result code. */
     atCoreStatus = Cellular_ATGetNextTok( &pLocalInputLine, &pToken );
 


### PR DESCRIPTION
Adds Cellular_Ping() using the same synchronous queue/URC pattern as Cellular_GetHostByName:
- pktPingQueue and pingEventCallback added to cellularModuleContext_t
- Queue created/destroyed alongside pktDnsQueue in cellular_bg96.c
- _Cellular_ProcessPingUrc registered in CellularUrcHandlerTable for the "QPING" prefix; fires callback on failure URC (+QPING: <nonzero>) or first echo-reply (+QPING: 0,"<ip>",...), ignores summary line
- Cellular_Ping in cellular_bg96_api.c: locks contextMutex, resets queue, registers callback, sends AT+QPING=<ctx>,"<host>",<t>,1, waits (timeoutS + 2s) for the URC via xQueueReceive

Returns 0 on success, modem error code on failure (565, 569), or -1 if the URC was not received within the timeout.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
